### PR TITLE
draft: integrate pantella-wow addon via submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "addons/pantella-wow"]
+	path = addons/pantella-wow
+	url = https://github.com/niStee/pantella-wow.git

--- a/src/conversation_managers/base_conversation_manager.py
+++ b/src/conversation_managers/base_conversation_manager.py
@@ -211,3 +211,7 @@ class BaseConversationManager:
         """Reload the conversation - Used when the conversation has ended or the conversation limit has been reached"""
         self.character_manager.reached_conversation_limit()
         self.messages = self.messages[-self.config.reload_buffer:] # save the last few messages to reload the conversation
+
+    def shutdown(self):
+        """Override in subclasses to perform cleanup. Default: no-op."""
+        pass


### PR DESCRIPTION
## Proposal

This PR adds `pantella-wow` as a git submodule under `addons/`, following the existing addon directory convention used by `openai_api_addon`, `vanilla_guards`, and `template_addon_slug_1`.

### What is pantella-wow?

`pantella-wow` is a World of Warcraft NPC AI addon for Pantella. It provides:

- WoW game interface integration (memory reading, event hooks)
- Character database and conversation management for WoW NPCs
- Compatibility layer bridging Pantella's Skyrim-focused architecture to WoW

The addon is developed independently at [github.com/niStee/pantella-wow](https://github.com/niStee/pantella-wow) with its own CI/CD, testing, and release pipeline.

### Why a submodule?

The submodule approach keeps `pantella-wow` as a self-contained project with its own:
- Release cycle (release-please automation)
- CI pipeline (tests, linting, security scanning)
- License (GPLv3)
- Dependencies (requirements.txt)

While making it easy for Pantella users to discover and enable the WoW addon.

### Questions for the maintainer

1. **Is this the right approach?** Should third-party addons live as submodules in the upstream repo, or should `addons/` only contain built-in examples?
2. **Submodule vs. subtree?** Would a subtree merge be preferred for tighter integration?
3. **Branch strategy?** Should the submodule track `main` or a tagged release?

Opening as a **draft** to discuss the approach before polishing. Happy to adjust based on your feedback.

### Test plan

- [ ] `git clone --recurse-submodules` works correctly
- [ ] Pantella starts without errors with the submodule present
- [ ] WoW addon loads when the submodule is populated
- [ ] No impact on existing addons (`openai_api_addon`, `vanilla_guards`, `template_addon_slug_1`)